### PR TITLE
remove setInterval with Queue module

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -61,10 +61,9 @@ const App = () => {
   const [emote, setEmote] = useState('');
 
   useEffect(() => {
-    let ballQueue = [];
+    let ballQueue = Utils.Queue(config.timings.timeBetweenRolls);
 
-    const ballRoll = async () => {
-      const item = ballQueue.shift();
+    const ballRoll = async (item) => {
       startGame(setRolling, setPanelTitle, setBallResponse, setCurrentPlayer, item);
       await Utils.wait(config.timings.ballRoll);
       endGame(
@@ -82,15 +81,9 @@ const App = () => {
     client.on('message', (channel, tags, message, self) => {
       if (self) return;
       if (tags['custom-reward-id'] === config.ballRollReward) {
-        ballQueue.push({ user: tags.username, message });
+        ballQueue.push(_ => ballRoll({ user: tags.username, message }));
       }
     });
-
-    setInterval(() => {
-      if (ballQueue.length > 0) {
-        ballRoll();
-      }
-    }, config.timings.checkInterval);
   }, []);
 
   return (

--- a/src/Utils.test.js
+++ b/src/Utils.test.js
@@ -5,3 +5,44 @@ test('getResponse() returns a random response', () => {
   const randomResponse = Utils.getBallResponse();
   expect(responses.includes(randomResponse)).toBe(true);
 });
+
+
+test('Queue immediately fires first event', () => {
+  let count = 0
+  const queue = Utils.Queue(5000)
+  queue.push(_ => { count++ })
+
+  expect(count).toBe(1)
+})
+
+test('Queue waits delay ms before firing second event', async () => {
+  const delay = 300
+  let count = 0
+  const queue = Utils.Queue(delay)
+  queue.push(_ => { count++ })
+  queue.push(_ => { count++ })
+
+  expect(count).toBe(1)
+  await Utils.wait(delay + 100) // wait 100ms more for calculation overhead
+  expect(count).toBe(2)
+})
+
+test('Queue takes ~3 delays to handle 4 events', async () => {
+  const delay = 300
+  let count = 0
+  const queue = Utils.Queue(delay)
+
+  // queue four events
+  queue.push(_ => { count++ })
+  queue.push(_ => { count++ })
+  queue.push(_ => { count++ })
+  queue.push(_ => { count++ })
+
+  const delays = (count) =>
+    delay * count + 100 // adds 100 more for calculation overhead
+
+  expect(count).toBe(1)
+  Utils.wait(delays(1)).then(_ => expect(count).toBe(2))
+  Utils.wait(delays(2)).then(_ => expect(count).toBe(3))
+  await Utils.wait(delays(3)).then(_ => expect(count).toBe(4))
+})

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,6 @@ export default {
   timings: {
     ballRoll: 5000,
     showResponse: 10000,
-    checkInterval: 16000,
+    timeBetweenRolls: 16000,
   },
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import responses from './responses';
+import { Queue } from './utils/Queue';
 
 export default class Utils {
   static wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -6,4 +7,6 @@ export default class Utils {
   static getBallResponse = () => {
     return responses[Math.floor(Math.random() * responses.length)];
   };
+
+  static Queue = Queue
 }

--- a/src/utils/Queue.js
+++ b/src/utils/Queue.js
@@ -1,0 +1,36 @@
+// Create a queue that waits `delay` milliseconds
+// before handling the next item
+export const Queue = (delay = 0) => {
+  // This is where we'll track items to work on
+  let locked = false
+  let items = []
+
+  // We'll call this whenever we want to run
+  // the first item in our queue
+  const attempt = () => {
+    if (items.length > 0 && locked === false) {
+      setLockTimer()
+      const fn = items.shift()
+      fn()
+    }
+  }
+
+  const setLockTimer = () => {
+    locked = true      // immediately locks queue
+    setTimeout(_ => {
+      locked = false   // unlocks when complete
+      attempt()        // attempts to run again when available
+    }, delay)
+  }
+
+  return {
+    push(fn) {
+      // prevent bad times with a helpful message
+      if (typeof fn !== 'function')
+        return console.warn('Must pass "queue.push" a function!')
+
+      items.push(fn) // add work to the queue
+      attempt()      // immediately attempt to run it
+    }
+  }
+}


### PR DESCRIPTION
### Description

Hey @whitep4nth3r , this is a PR inspired by Obando's approach. I really like the idea of eliminating the setInterval so that requests can fire right away.

I've added a few tests to the `Utils.tests.js` file, and updated our ball code to use the new queue.

Let me know if there's anything I need to tweak!

Here's a codepen demoing how the queue works:
https://codepen.io/RyanNHG/pen/PoNjOMz

### Other Notes

You may notice an extra `+ 100` in the tests. As you'll see in the Codepen demo above, there's a bit of overhead for calling the functions that adds up over time. Adding 100ms to each delay helps ensure the queue finishes in time, so that the tests don't inconsistently fail.

(For example: 2 events fired with a `300ms` delay might actually take `315ms` to complete)